### PR TITLE
fix: range value of time multiplier

### DIFF
--- a/src/Parsing/Plazza.cpp
+++ b/src/Parsing/Plazza.cpp
@@ -18,8 +18,8 @@ PlazzaParser::PlazzaParser(int argc, char **argv)
 
     try {
         _timeMultiplier = std::stod(argv[1]);
-        if (_timeMultiplier < 0 || _timeMultiplier > 1)
-            throw PlazzaParser::ParserException("Error: Invalid time multiplier, must be between 0 and 1");
+        if (_timeMultiplier < 0)
+            throw PlazzaParser::ParserException("Error: Invalid time multiplier, must be positive values");
     } catch (std::invalid_argument &e) {
         throw PlazzaParser::ParserException("Error: Invalid time multiplier, must be a valid number");
     }


### PR DESCRIPTION
I have corrected the value of the time multiplier range.

Before my correction, the value of the range was between 0 and 1. Now the value must be positive.